### PR TITLE
Set owner of the workspace directory

### DIFF
--- a/includes/download.yaml
+++ b/includes/download.yaml
@@ -2,6 +2,7 @@
 - name: GitHub Actions Runner | Create workspace
   ansible.builtin.file:
     path: "{{ gh_runner_workspace_path }}"
+    owner: "{{ ansible_user_id }}"
     state: directory
     mode: 0755
   become: true


### PR DESCRIPTION
This change fixes a permissions problem when the ansible user is not root. Making sure the `gh_runner_workspace_path` directory is owned by the same user the runner is configured to run as.