### PR TITLE
Configurable service user

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -33,6 +33,9 @@ gh_runner_workspace_path: /var/cache/github-actions-runner
 # complement with the --tag uninstall
 gh_runner_remove_host: false
 
+# If set then the GitHub Actions service will be installed to run as this user.
+gh_runner_service_user: ""
+
 ## Variables used to set parameters to the `config.sh` script.
 
 # (REQUIRED) GitHub Actions repository URL to register this self-hosted runner.

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -33,8 +33,8 @@ gh_runner_workspace_path: /var/cache/github-actions-runner
 # complement with the --tag uninstall
 gh_runner_remove_host: false
 
-# If set then the GitHub Actions service will be installed to run as this user.
-gh_runner_service_user: ""
+# Run GitHub Actions service will be installed to run as this user.
+gh_runner_service_user: "{{ ansible_user_id }}"
 
 ## Variables used to set parameters to the `config.sh` script.
 

--- a/includes/download.yaml
+++ b/includes/download.yaml
@@ -38,7 +38,6 @@
         remote_src: true
       register: gh_runner_path_unarchived
       become: true
-      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: GitHub Actions Runner | Set permissions
       ansible.builtin.file:

--- a/includes/download.yaml
+++ b/includes/download.yaml
@@ -38,6 +38,7 @@
         remote_src: true
       register: gh_runner_path_unarchived
       become: true
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: GitHub Actions Runner | Set permissions
       ansible.builtin.file:

--- a/includes/install.yaml
+++ b/includes/install.yaml
@@ -116,7 +116,7 @@
 
 - name: GitHub Actions Runner | Install service
   ansible.builtin.command:
-    cmd: "{{ gh_runner_path }}/svc.sh install"
+    cmd: "{{ gh_runner_path }}/svc.sh install {{ gh_runner_service_user }}"
     chdir: "{{ gh_runner_path }}"
   become: true
   when: not is_this_host_token_registered.stat.exists

--- a/includes/install.yaml
+++ b/includes/install.yaml
@@ -76,10 +76,10 @@
         --labels {{ gh_runner_config_labels | join(',') }}
     chdir: "{{ gh_runner_path }}"
   register: config_host_command
-
   when: not is_this_host_token_registered.stat.exists
   tags:
     - configure
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: GitHub Actions Runner | Check if path for state files exists
   ansible.builtin.stat:
@@ -122,6 +122,7 @@
   when: not is_this_host_token_registered.stat.exists
   tags:
     - install
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: GitHub Actions Runner | Check service status
   ansible.builtin.command:
@@ -132,6 +133,7 @@
   become: true
   tags:
     - configure
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: GitHub Actions Runner | Start service
   ansible.builtin.command:
@@ -141,3 +143,4 @@
   become: true
   tags:
     - configure
+  ignore_errors: "{{ ansible_check_mode }}"

--- a/includes/install.yaml
+++ b/includes/install.yaml
@@ -76,10 +76,10 @@
         --labels {{ gh_runner_config_labels | join(',') }}
     chdir: "{{ gh_runner_path }}"
   register: config_host_command
+
   when: not is_this_host_token_registered.stat.exists
   tags:
     - configure
-  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: GitHub Actions Runner | Check if path for state files exists
   ansible.builtin.stat:
@@ -122,7 +122,6 @@
   when: not is_this_host_token_registered.stat.exists
   tags:
     - install
-  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: GitHub Actions Runner | Check service status
   ansible.builtin.command:
@@ -133,7 +132,6 @@
   become: true
   tags:
     - configure
-  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: GitHub Actions Runner | Start service
   ansible.builtin.command:
@@ -143,4 +141,3 @@
   become: true
   tags:
     - configure
-  ignore_errors: "{{ ansible_check_mode }}"


### PR DESCRIPTION
This change makes is possible to configure which user the service is installed to run as with `gh_runner_service_user`. This is useful when running the service as a different user than the ansible user.

This also includes a change to ignore errors for some tasks when running with `--check` flag.

