### PR TITLE
Fix folders permissions when using a service user other than root or the ansible ssh user

### DIFF
--- a/includes/download.yaml
+++ b/includes/download.yaml
@@ -2,7 +2,7 @@
 - name: GitHub Actions Runner | Create workspace
   ansible.builtin.file:
     path: "{{ gh_runner_workspace_path }}"
-    owner: "{{ ansible_user_id }}"
+    owner: "{{ gh_runner_service_user }}"
     state: directory
     mode: 0755
   become: true
@@ -42,7 +42,7 @@
     - name: GitHub Actions Runner | Set permissions
       ansible.builtin.file:
         path: "{{ gh_runner_path }}"
-        owner: "{{ ansible_user_id }}"
+        owner: "{{ gh_runner_service_user }}"
         mode: 0755
         recurse: true
       become: true

--- a/includes/install.yaml
+++ b/includes/install.yaml
@@ -93,7 +93,7 @@
   ansible.builtin.file:
     path: "{{ gh_runner_path }}/hosts"
     state: directory
-    owner: "{{ ansible_user_id }}"
+    owner: "{{ gh_runner_service_user }}"
     mode: 0755
   become: true
   when: not registered_hosts_path.stat.exists

--- a/includes/install.yaml
+++ b/includes/install.yaml
@@ -49,6 +49,8 @@
       become: true
 
     - name: GitHub Actions Runner | Remove previous configuration before proceeding
+      become: true
+      become_user: "{{ gh_runner_service_user }}"
       ansible.builtin.command:
         cmd: |-
           {{ gh_runner_path }}/config.sh remove \
@@ -65,6 +67,8 @@
     - configure
 
 - name: GitHub Actions Runner | Configure Runner
+  become: true
+  become_user: "{{ gh_runner_service_user }}"
   ansible.builtin.command:
     cmd: |-
       {{ gh_runner_path }}/config.sh \


### PR DESCRIPTION
This PR fixes the permissions issues encountered when using a `gh_runner_service_user` other than `root` or `ansible_user_id`.
Without those updates, we hit permissions issues when the service is started:
```
Unhandled exception. System.UnauthorizedAccessException: Access to the path '/usr/local/share/github-actions-runner/2.299.1/065e1c29ac78deb2f7715e81a5df90915c937ad486cc96a63bf1fcd36c02d41e/_diag/Runner_20221117-072721-utc.log' is denied.
```